### PR TITLE
Add plot rotation option

### DIFF
--- a/R/data.plot.R
+++ b/R/data.plot.R
@@ -160,7 +160,6 @@ data.plot <- function(
         om + 
         theme(axis.text.x = element_text(angle = 90, hjust = 1),
               legend.title=element_blank(),
-              # plot.margin=unit(c(25, 5.5, 5.5, 50), "points"),
               plot.margin=unit(c(25, 5.5, 50, 5.5), "points"),
               strip.text.y = element_text(angle = 90),
               text = element_text(size=text.size)) +

--- a/R/data.plot.R
+++ b/R/data.plot.R
@@ -19,6 +19,9 @@
 #' the studies reporting the median as turquoise.
 #' @param avg.hline If TRUE, adds overall average line to plot. Default is TRUE.
 #' @param text.size Font size of the text. Default is 20.
+#' @param orientation An optional string indicating the orientation of the plot. Default is "landscape".
+#' (The plot expands width-ways with additional studies). 
+#' If "portrait", the plot is rotated 90° and expands length-ways with additional studies.
 #'              
 #' @seealso
 #' \code{\link{data.prep}}
@@ -59,7 +62,8 @@ data.plot <- function(
   by = "study",
   avg.hline = TRUE,
   fill.str = NULL,
-  text.size = 20
+  text.size = 20,
+  orientation = "landscape"
 ){
   
   if (!inherits(data, 'BUGSnetData'))
@@ -68,7 +72,8 @@ data.plot <- function(
   patients.data <- data$arm.data
   treatment.var <- data$varname.t
   trial.var <- data$varname.s
-  y.lab <- covariate.label
+  axis.lab <- covariate.label
+  
   if(is.null(half.length)){
     errorbar = FALSE
     errorbar.min = NULL
@@ -86,49 +91,102 @@ data.plot <- function(
     stop('When errorbar = TRUE, errorbar.min and errorbar.max must be specified')
     }
   
-  if (errorbar){eb = geom_errorbar(aes_string(ymin=errorbar.min, ymax=errorbar.max))}
-  else {eb = NULL}
+  if (orientation == "landscape") {
   
-  if (avg.hline){
-    overall.mean <- patients.data %>% select(covariate) %>% colMeans(na.rm=TRUE) %>% as.numeric()
-    om <- geom_hline(yintercept = overall.mean, color = "red", linetype=2)}
-  else{om=NULL}
-  
-  patients.data <- patients.data %>%
-    mutate(trt =(!! as.name(treatment.var)), trial =(!! as.name(trial.var)))
-  
-  if (by == "study"){
-  if(is.null(fill.str)) {p <- ggplot(patients.data, aes_string(x=treatment.var, y=covariate))}
-  else p <- ggplot(patients.data, aes_string(x=treatment.var, y=covariate, color=fill.str))
-  
-  p <- p + geom_point() +
-    eb +
-    om + 
-    theme(axis.text.x = element_text(angle = 90, hjust = 1),
-          legend.title=element_blank(),
-          plot.margin=unit(c(25, 5.5, 5.5, 50), "points"),
-          strip.text.x = element_text(angle = 90),
-          text = element_text(size=text.size)) +
-    labs(y = y.lab, x="", caption = caption)+
-    facet_grid(. ~ trial,  space="free_x", scales="free_x")
-  
-  }
-  else if (by == "treatment"){
+    if (errorbar){eb = geom_errorbar(aes_string(ymin=errorbar.min, ymax=errorbar.max))}
+    else {eb = NULL}
     
-  if(is.null(fill.str)) {p <- ggplot(patients.data, aes_string(x=trial.var, y=covariate))}
-  else p <- ggplot(patients.data, aes_string(x=trial.var, y=covariate, color=fill.str))
-  
-  p <- p + geom_point() +
-    eb +
-    om + 
-    theme(axis.text.x = element_text(angle = 90, hjust = 1),
-          legend.title=element_blank(),
-         plot.margin=unit(c(10, 4, 4, 20), "points"),
-          strip.text.x = element_text(angle = 90),
-         text = element_text(size=text.size)) +
-    labs(y = y.lab, x="", caption = caption)+
-    facet_grid(. ~ trt,  space="free_x", scales="free_x")
-  
+    if (avg.hline){
+      overall.mean <- patients.data %>% select(covariate) %>% colMeans(na.rm=TRUE) %>% as.numeric()
+      om <- geom_hline(yintercept = overall.mean, color = "red", linetype=2)}
+    else{om=NULL}
+    
+    patients.data <- patients.data %>%
+      mutate(trt =(!! as.name(treatment.var)), trial =(!! as.name(trial.var)))
+    
+    if (by == "study"){
+    if(is.null(fill.str)) {p <- ggplot(patients.data, aes_string(x=treatment.var, y=covariate))}
+    else p <- ggplot(patients.data, aes_string(x=treatment.var, y=covariate, color=fill.str))
+    
+    p <- p + geom_point() +
+      eb +
+      om + 
+      theme(axis.text.x = element_text(angle = 90, hjust = 1),
+            legend.title=element_blank(),
+            plot.margin=unit(c(25, 5.5, 5.5, 50), "points"),
+            strip.text.x = element_text(angle = 90),
+            text = element_text(size=text.size)) +
+      labs(y = axis.lab, x="", caption = caption)+
+      facet_grid(. ~ trial,  space="free_x", scales="free_x")
+    
+    }
+    else if (by == "treatment"){
+      
+    if(is.null(fill.str)) {p <- ggplot(patients.data, aes_string(x=trial.var, y=covariate))}
+    else p <- ggplot(patients.data, aes_string(x=trial.var, y=covariate, color=fill.str))
+    
+    p <- p + geom_point() +
+      eb +
+      om + 
+      theme(axis.text.x = element_text(angle = 90, hjust = 1),
+            legend.title=element_blank(),
+           plot.margin=unit(c(10, 4, 4, 20), "points"),
+            strip.text.x = element_text(angle = 90),
+           text = element_text(size=text.size)) +
+      labs(y = axis.lab, x="", caption = caption)+
+      facet_grid(. ~ trt,  space="free_x", scales="free_x")
+    
+    }
+    
+  } else if (orientation == "portrait") {
+    
+    if (errorbar){eb = geom_errorbar(aes_string(xmin=errorbar.min, xmax=errorbar.max))}
+    else {eb = NULL}
+    
+    if (avg.hline){
+      overall.mean <- patients.data %>% select(covariate) %>% colMeans(na.rm=TRUE) %>% as.numeric()
+      om <- geom_vline(xintercept = overall.mean, color = "red", linetype=2)}
+    else{om=NULL}
+    
+    patients.data <- patients.data %>%
+      mutate(trt =(!! as.name(treatment.var)), trial =(!! as.name(trial.var)))
+    
+    if (by == "study"){
+      if(is.null(fill.str)) {p <- ggplot(patients.data, aes_string(x=covariate, y=treatment.var))}
+      else p <- ggplot(patients.data, aes_string(x=covariate, y=treatment.var, color=fill.str))
+      
+      p <- p + geom_point() +
+        eb +
+        om + 
+        theme(axis.text.x = element_text(angle = 90, hjust = 1),
+              legend.title=element_blank(),
+              # plot.margin=unit(c(25, 5.5, 5.5, 50), "points"),
+              plot.margin=unit(c(25, 5.5, 50, 5.5), "points"),
+              strip.text.y = element_text(angle = 90),
+              text = element_text(size=text.size)) +
+        labs(x = axis.lab, y="", caption = caption)+
+        facet_grid(trial ~ .,  space="free_y", scales="free_y") +
+        theme(strip.text.y = element_text(angle = 0)) # Rotates facet label
+      
+    }
+    else if (by == "treatment"){
+      
+      if(is.null(fill.str)) {p <- ggplot(patients.data, aes_string(x=covariate, y=trial.var))}
+      else p <- ggplot(patients.data, aes_string(x=covariate, y=trial.var, color=fill.str))
+      
+      p <- p + geom_point() +
+        eb +
+        om + 
+        theme(axis.text.x = element_text(angle = 90, hjust = 1),
+              legend.title=element_blank(),
+              plot.margin=unit(c(10, 4, 20, 4), "points"),
+              strip.text.y = element_text(angle = 90),
+              text = element_text(size=text.size)) +
+        labs(x = axis.lab, y="", caption = caption)+
+        facet_grid(trt ~ .,  space="free_y", scales="free_y") +
+        theme(strip.text.y = element_text(angle = 0)) # Rotates facet label
+      
+    }
   }
   p
 }


### PR DESCRIPTION
Adds landscape vs portrait option to change orientation to plot. Default is existing plot layout.

Notes:
- I have mostly kept the existing code and added an additional if/else to do the landscape vs portrait. This does mean there is some replication of code but I didn't want to change too much of the existing code
- I have replicated the existing style
- We only use the option `by <- "treatment"` in MetaInsight, but I have included code for the `by <- "study"` option

The following example dataset from BUGSnet is the one I have been using for testing:

`diabetes.slr <- BUGSnet::data.prep(arm.data = diabetes.sim, 
                          varname.t = "Treatment", 
                          varname.s = "Study")`

with the following arguments

`data <- diabetes.slr
covariate <- "age"
covariate.label <- "Age"
half.length <- "age_SD"
avg.hline <- TRUE
by <- "treatment"
fill.str <- NULL
text.size <- 20
orientation <- "portrait"`

Changing `by <- "treatment"` to `by <- "study"` and `orientation <- "portrait"` to `orientation <- "landscape"` as necessary to check all permutations.

